### PR TITLE
Fix build.gradle to prevent Aapt2Exception

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion '26.0.2'
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
         ndk {
@@ -19,8 +23,8 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
-    compile 'com.google.zxing:core:3.3.0'
-    compile group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.9.1'
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation 'com.android.support:recyclerview-v7:25.0.1'
+    implementation 'com.google.zxing:core:3.3.0'
+    implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.9.1'
 }


### PR DESCRIPTION
Hi All,

I've noticed other Pull Requests for the same thing, but none of them respected the variables set in the master build.gradle as to what compileSdkVersion, buildToolsVersion, etc to use

This solves the error
```
Execution failed for task ':rncamerakit:verifyReleaseResources'.
> java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
node_modules\react-native-camera-kit\android\build\intermediates\res\merged\release\values-v26\values-v26.xml:7: error: resource android:attr/colorError not found.
  node_modules\react-native-camera-kit\android\build\intermediates\res\merged\release\values-v26\values-v26.xml:11: error: resource android:attr/colorError not found.
node_modules\react-native-camera-kit\android\build\intermediates\res\merged\release\values-v26\values-v26.xml:15: error: style attribute 'android:attr/keyboardNavigationCluster' not found.
```

I've taken the same approch as react native vector icons uses here https://github.com/oblador/react-native-vector-icons/blob/master/android/build.gradle 